### PR TITLE
added styles gulp task dz-05

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,29 +1,22 @@
 var gulp = require('gulp');
 var browserSync = require('browser-sync').create();
 var less = require('gulp-less');
-var sass = require('gulp-sass');
 
-gulp.task('server', ['sass'], function() {
+gulp.task('server', ['styles'], function() {
     browserSync.init({
     	server: { baseDir: './app/'}
     });
     gulp.watch('./app/**/*.html').on('change', browserSync.reload);
     // gulp.watch('./app/less/**/*.less', ['less']);
-    gulp.watch('./app/sass/**/*.scss', ['sass']);
+    gulp.watch('./app/less/**/*.less', ['styles']);
 });
 
-gulp.task('less', function() {
+gulp.task('styles', function() {
     return gulp.src('./app/less/**/*.less')
     .pipe(less())
     .pipe(gulp.dest('./app/css'))
     .pipe(browserSync.stream());
 });
 
-gulp.task('sass', function() {
-    return gulp.src('./app/sass/**/*.scss')
-    .pipe(sass())
-    .pipe(gulp.dest('./app/css'))
-    .pipe(browserSync.stream());
-});
 
 gulp.task('default', ['server']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ gulp.task('server', ['styles'], function() {
     	server: { baseDir: './app/'}
     });
     gulp.watch('./app/**/*.html').on('change', browserSync.reload);
-    // gulp.watch('./app/less/**/*.less', ['less']);
+
     gulp.watch('./app/less/**/*.less', ['styles']);
 });
 


### PR DESCRIPTION
при установке зависимостей npm показало следующее
$ npm i
npm WARN tarball tarball data for ajv@4.11.8 (sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=) seems to be corrupted. Trying one more time.
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\bs-recipes-690956fb\recipes\server.includes\app\css\main.css'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less-bom\strict-units\strict-units.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\node-sass-c53b8133\test\fixtures\watcher\sibling\partials\_three.scss'
npm WARN tar ENOENT: no such file or directory, lstat 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\node-sass-c53b8133\test\fixtures\watcher\sibling'
npm WARN tar ENOENT: no such file or directory, lstat 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\bs-recipes-690956fb\recipes\webpack.babel\app'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\bs-recipes-690956fb\recipes\webpack.babel\desc.md'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\node-sass-c53b8133\test\fixtures\watching-dir-01\index.scss'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\bs-recipes-690956fb\recipes\webpack.babel\readme.md'
npm WARN tar ENOENT: no such file or directory, lstat 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\bs-recipes-690956fb\recipes'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\appender-reference-1968.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\global-scope-import.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\global-scope-nested.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\mixin-1968.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\multiple-import-nested.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\multiple-import.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\simple-mixin.css'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\less\import-reference-issues\simple-ruleset-2162.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\browser\less\urls.less'
npm WARN tar ENOENT: no such file or directory, open 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test\browser\test-runner-template.tmpl'
npm WARN tar ENOENT: no such file or directory, lstat 'C:\Users\Админ\Desktop\dz-gulp-1\node_modules\.staging\less-338165b2\test'
npm WARN gulp-project@1.0.0 No description
npm WARN gulp-project@1.0.0 No repository field.



